### PR TITLE
User access tokens.

### DIFF
--- a/application/api/v1/api.py
+++ b/application/api/v1/api.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 
+from .endpoints import access_tokens
 from .endpoints import applications
 from .endpoints import authorization
 from .endpoints import dashboard
@@ -16,6 +17,8 @@ from .endpoints import users
 
 router = APIRouter()
 
+
+router.include_router(access_tokens.router, prefix='/access-token', tags=['access tokens'])
 
 router.include_router(applications.router, prefix='/application', tags=['applications'])
 

--- a/application/api/v1/endpoints/access_tokens.py
+++ b/application/api/v1/endpoints/access_tokens.py
@@ -10,6 +10,7 @@ from fastapi import Depends
 from fastapi import Path
 
 from core.authentication import AuthorizedUser
+from core.authentication import OperatorRolePermission
 from core.authentication import current_active_user
 from managers.access_tokens import AccessTokenManager
 from managers.access_tokens import get_access_token_manager
@@ -29,7 +30,11 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.post('/', response_model=AccessTokenResponseSchema, dependencies=[Depends(AuthorizedUser())])
+@router.post(
+    '/',
+    response_model=AccessTokenResponseSchema,
+    dependencies=[Depends(AuthorizedUser(OperatorRolePermission))]
+)
 async def create_access_token(
     data: CreateSchema = Body(description='Access token create data.'),
     creator: User = Depends(current_active_user),
@@ -50,7 +55,11 @@ async def create_access_token(
     return token
 
 
-@router.get('/list/', response_model=list[AccessTokenResponseSchema], dependencies=[Depends(AuthorizedUser())])
+@router.get(
+    '/list',
+    response_model=list[AccessTokenResponseSchema],
+    dependencies=[Depends(AuthorizedUser(OperatorRolePermission))]
+)
 async def list_access_tokens(
     user: User = Depends(current_active_user),
     token_manager: AccessTokenManager = Depends(get_access_token_manager)
@@ -64,7 +73,7 @@ async def list_access_tokens(
 @router.post(
     '/{token}/expiration-date',
     response_model=AccessTokenResponseSchema,
-    dependencies=[Depends(AuthorizedUser())]
+    dependencies=[Depends(AuthorizedUser(OperatorRolePermission))]
 )
 async def set_access_token_expiration_date(
     token: UUID = Path(title='Token to change.'),
@@ -81,7 +90,11 @@ async def set_access_token_expiration_date(
     return token_record
 
 
-@router.post('/{token}/comment', response_model=AccessTokenResponseSchema, dependencies=[Depends(AuthorizedUser())])
+@router.post(
+    '/{token}/comment',
+    response_model=AccessTokenResponseSchema,
+    dependencies=[Depends(AuthorizedUser(OperatorRolePermission))]
+)
 async def set_access_token_comment(
     token: UUID = Path(title='Token to change.'),
     body: SetCommentSchema = Body(description='Access token comment body.'),
@@ -97,7 +110,11 @@ async def set_access_token_comment(
     return token_record
 
 
-@router.post('/{token}/status', response_model=AccessTokenResponseSchema, dependencies=[Depends(AuthorizedUser())])
+@router.post(
+    '/{token}/status',
+    response_model=AccessTokenResponseSchema,
+    dependencies=[Depends(AuthorizedUser(OperatorRolePermission))]
+)
 async def set_access_token_status(
     token: UUID = Path(title='Token to change.'),
     body: SetStatusSchema = Body(description='Access token status body.'),
@@ -113,7 +130,11 @@ async def set_access_token_status(
     return token_record
 
 
-@router.delete('/{token}', response_model=list[AccessTokenResponseSchema], dependencies=[Depends(AuthorizedUser())])
+@router.delete(
+    '/{token}',
+    response_model=list[AccessTokenResponseSchema],
+    dependencies=[Depends(AuthorizedUser(OperatorRolePermission))]
+)
 async def delete_access_token(
     token: UUID = Path(title='Token to remove.'),
     user: User = Depends(current_active_user),

--- a/application/api/v1/endpoints/access_tokens.py
+++ b/application/api/v1/endpoints/access_tokens.py
@@ -1,0 +1,128 @@
+"""
+User access tokens related API endpoints.
+"""
+import logging
+from uuid import UUID
+
+from fastapi import APIRouter
+from fastapi import Body
+from fastapi import Depends
+from fastapi import Path
+
+from core.authentication import AuthorizedUser
+from core.authentication import current_active_user
+from managers.access_tokens import AccessTokenManager
+from managers.access_tokens import get_access_token_manager
+from managers.users import UserManager
+from managers.users import get_user_manager
+from models.user import User
+
+from ..schemas.access_tokens import AccessTokenResponseSchema
+from ..schemas.access_tokens import CreateSchema
+from ..schemas.access_tokens import SetCommentSchema
+from ..schemas.access_tokens import SetExpirationDateSchema
+from ..schemas.access_tokens import SetStatusSchema
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.post('/', response_model=AccessTokenResponseSchema, dependencies=[Depends(AuthorizedUser())])
+async def create_access_token(
+    data: CreateSchema = Body(description='Access token create data.'),
+    creator: User = Depends(current_active_user),
+    user_manager: UserManager = Depends(get_user_manager),
+    token_manager: AccessTokenManager = Depends(get_access_token_manager)
+):
+    """
+    Create new user access token.
+    """
+    user = await user_manager.get(data.user)
+    token = await token_manager.create(
+        creator=creator,
+        user=user,
+        comment=data.comment,
+        expiration_date=data.expiration_date
+    )
+
+    return token
+
+
+@router.get('/list/', response_model=list[AccessTokenResponseSchema], dependencies=[Depends(AuthorizedUser())])
+async def list_access_tokens(
+    user: User = Depends(current_active_user),
+    token_manager: AccessTokenManager = Depends(get_access_token_manager)
+):
+    """
+    Returns list of organization's user access tokens.
+    """
+    return await token_manager.list_organization_access_tokens(user.organization)
+
+
+@router.post(
+    '/{token}/expiration-date',
+    response_model=AccessTokenResponseSchema,
+    dependencies=[Depends(AuthorizedUser())]
+)
+async def set_access_token_expiration_date(
+    token: UUID = Path(title='Token to change.'),
+    body: SetExpirationDateSchema = Body(description='Access token expiration date body.'),
+    user: User = Depends(current_active_user),
+    token_manager: AccessTokenManager = Depends(get_access_token_manager)
+):
+    """
+    Sets user access token expiration date.
+    """
+    token_record = await token_manager.get_access_token(user.organization, token)
+    await token_manager.set_expiration_date(token_record, body.expiration_date)
+
+    return token_record
+
+
+@router.post('/{token}/comment', response_model=AccessTokenResponseSchema, dependencies=[Depends(AuthorizedUser())])
+async def set_access_token_comment(
+    token: UUID = Path(title='Token to change.'),
+    body: SetCommentSchema = Body(description='Access token comment body.'),
+    user: User = Depends(current_active_user),
+    token_manager: AccessTokenManager = Depends(get_access_token_manager)
+):
+    """
+    Sets user access token comment.
+    """
+    token_record = await token_manager.get_access_token(user.organization, token)
+    await token_manager.set_comment(token_record, body.comment)
+
+    return token_record
+
+
+@router.post('/{token}/status', response_model=AccessTokenResponseSchema, dependencies=[Depends(AuthorizedUser())])
+async def set_access_token_status(
+    token: UUID = Path(title='Token to change.'),
+    body: SetStatusSchema = Body(description='Access token status body.'),
+    user: User = Depends(current_active_user),
+    token_manager: AccessTokenManager = Depends(get_access_token_manager)
+):
+    """
+    Sets user access token status.
+    """
+    token_record = await token_manager.get_access_token(user.organization, token)
+    await token_manager.set_status(token_record, body.status)
+
+    return token_record
+
+
+@router.delete('/{token}', response_model=list[AccessTokenResponseSchema], dependencies=[Depends(AuthorizedUser())])
+async def delete_access_token(
+    token: UUID = Path(title='Token to remove.'),
+    user: User = Depends(current_active_user),
+    token_manager: AccessTokenManager = Depends(get_access_token_manager)
+):
+    """
+    Deletes organization's user access token.
+    """
+    token_record = await token_manager.get_access_token(user.organization, token)
+    await token_manager.delete_access_token(token_record, user)
+
+    return await token_manager.list_organization_access_tokens(user.organization)

--- a/application/api/v1/endpoints/authorization.py
+++ b/application/api/v1/endpoints/authorization.py
@@ -1,7 +1,6 @@
 from fastapi import APIRouter
 
-from core.authentication import auth_backend
-from core.authentication import permanent_jwt_auth_backend
+from core.authentication import jwt_backend
 from core.authentication import fastapi_users
 from core.authentication import github_client
 from core.authentication import google_client
@@ -13,8 +12,7 @@ from schemas.users import UserRead
 router = APIRouter()
 
 
-router.include_router(fastapi_users.get_auth_router(auth_backend), prefix='/jwt')
-router.include_router(fastapi_users.get_auth_router(permanent_jwt_auth_backend), prefix='/permanent-jwt')
+router.include_router(fastapi_users.get_auth_router(jwt_backend), prefix='/jwt')
 
 router.include_router(fastapi_users.get_register_router(UserRead, UserCreate))
 
@@ -22,12 +20,12 @@ router.include_router(fastapi_users.get_reset_password_router())
 
 router.include_router(fastapi_users.get_verify_router(UserRead))
 
-google_router = fastapi_users.get_oauth_router(google_client, auth_backend, settings.SECRET)
+google_router = fastapi_users.get_oauth_router(google_client, jwt_backend, settings.SECRET)
 router.include_router(google_router, prefix='/google')
 
 github_router = fastapi_users.get_oauth_router(
     github_client,
-    auth_backend,
+    jwt_backend,
     settings.SECRET,
     redirect_url=f'{settings.UI_HOST}/sign-in'
 )

--- a/application/api/v1/endpoints/authorization.py
+++ b/application/api/v1/endpoints/authorization.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
 from core.authentication import auth_backend
+from core.authentication import permanent_jwt_auth_backend
 from core.authentication import fastapi_users
 from core.authentication import github_client
 from core.authentication import google_client
@@ -13,6 +14,7 @@ router = APIRouter()
 
 
 router.include_router(fastapi_users.get_auth_router(auth_backend), prefix='/jwt')
+router.include_router(fastapi_users.get_auth_router(permanent_jwt_auth_backend), prefix='/permanent-jwt')
 
 router.include_router(fastapi_users.get_register_router(UserRead, UserCreate))
 

--- a/application/api/v1/schemas/access_tokens.py
+++ b/application/api/v1/schemas/access_tokens.py
@@ -2,7 +2,6 @@
 User access token related API schemas.
 """
 from datetime import datetime
-from datetime import timezone
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -51,7 +50,6 @@ class AccessTokenResponseSchema(AccessTokenBaseSchema):
     User access token response schema.
     """
     user: UserResponseSchema = Field(description='User that can use this token for access.')
-    creator: UserResponseSchema = Field(description='User that have created this access token.')
     organization: OrganizationResponseSchema = Field(description='Organization which own this access token.')
 
     class Config:

--- a/application/api/v1/schemas/access_tokens.py
+++ b/application/api/v1/schemas/access_tokens.py
@@ -1,0 +1,75 @@
+"""
+User access token related API schemas.
+"""
+from datetime import datetime
+from datetime import timezone
+from uuid import UUID
+
+from pydantic import BaseModel
+from pydantic import Field
+from pydantic import validator
+
+from constants.access_tokens import AccessTokenStatuses
+from schemas.access_tokens import AccessTokenBaseSchema
+
+from .common import OrganizationResponseSchema
+from .common import UserResponseSchema
+
+
+class SetExpirationDateSchema(BaseModel):
+    """
+    Request body for changing user access token expiration date.
+    """
+    expiration_date: datetime | None = Field(description='Date and time when token must become expired.')
+
+    @validator('expiration_date')
+    def expiration_date_validation(cls, value) -> datetime:
+        """
+        Converts to UTC and then validates expiration date.
+        """
+        if value is None:
+            return
+
+        # Making time naive(local).
+        value = value.astimezone(None).replace(tzinfo=None)
+        if value <= datetime.now():
+            raise ValueError('Expiration date can not be in past.')
+
+        return value
+
+
+class CreateSchema(SetExpirationDateSchema):
+    """
+    User invitation create request schema.
+    """
+    user: UUID = Field(description='User for which token need to be created.')
+    comment: str | None = Field(description='Description of token.')
+
+
+class AccessTokenResponseSchema(AccessTokenBaseSchema):
+    """
+    User access token response schema.
+    """
+    user: UserResponseSchema = Field(description='User that can use this token for access.')
+    creator: UserResponseSchema = Field(description='User that have created this access token.')
+    organization: OrganizationResponseSchema = Field(description='Organization which own this access token.')
+
+    class Config:
+        orm_mode = True
+        json_encoders = {
+            datetime: lambda v: v.timestamp()
+        }
+
+
+class SetStatusSchema(BaseModel):
+    """
+    Request body for changing user access token status.
+    """
+    status: AccessTokenStatuses = Field(description='New user access token status.')
+
+
+class SetCommentSchema(BaseModel):
+    """
+    Request body for changing user access token description.
+    """
+    comment: str | None = Field(description='Description of token.')

--- a/application/api/v1/schemas/access_tokens.py
+++ b/application/api/v1/schemas/access_tokens.py
@@ -41,7 +41,6 @@ class CreateSchema(SetExpirationDateSchema):
     """
     User invitation create request schema.
     """
-    user: UUID = Field(description='User for which token need to be created.')
     comment: str | None = Field(description='Description of token.')
 
 

--- a/application/api/v1/schemas/invitations.py
+++ b/application/api/v1/schemas/invitations.py
@@ -30,7 +30,7 @@ class CreateSchema(BaseModel):
 
 class InvitationResponseSchema(BaseModel):
     """
-    User registration by invitation request schema.
+    User registration by invitation response schema.
     """
     id: UUID = Field(description='User invitation ID')
     created_at: datetime = Field(description='Date and time of invitation creation in timestamp format')

--- a/application/constants/access_tokens.py
+++ b/application/constants/access_tokens.py
@@ -1,0 +1,12 @@
+"""
+User access token constants.
+"""
+from .base_enum import StrEnum
+
+
+class AccessTokenStatuses(StrEnum):
+    """
+    User access token statuses.
+    """
+    active = 'active'
+    disabled = 'disabled'

--- a/application/constants/events.py
+++ b/application/constants/events.py
@@ -8,10 +8,11 @@ class EventCategory(StrEnum):
     """
     Event severity levels.
     """
+    access_token = 'access_token'
     application = 'application'
+    helm = 'helm'
     hook = 'hook'
     organization = 'organization'
-    helm = 'helm'
 
 
 class EventSeverityLevel(StrEnum):

--- a/application/core/authentication.py
+++ b/application/core/authentication.py
@@ -68,13 +68,23 @@ def get_jwt_strategy() -> CustomPayloadJWTStrategy:
     return CustomPayloadJWTStrategy(secret=settings.SECRET, lifetime_seconds=settings.USER_SESSION_TTL)
 
 
-auth_backend = AuthenticationBackend(
-    name='jwt',
-    transport=bearer_transport,
-    get_strategy=get_jwt_strategy,
+auth_backend = AuthenticationBackend(name='jwt', transport=bearer_transport, get_strategy=get_jwt_strategy,)
+
+
+permanent_jwt_bearer_transport = BearerTransport(tokenUrl='api/v1/auth/permanent-jwt/login')
+
+
+def get_permanent_jwt_strategy() -> CustomPayloadJWTStrategy:
+    return CustomPayloadJWTStrategy(secret=settings.SECRET, lifetime_seconds=None)
+
+
+permanent_jwt_auth_backend = AuthenticationBackend(
+    name='permanent-jwt',
+    transport=permanent_jwt_bearer_transport,
+    get_strategy=get_permanent_jwt_strategy
 )
 
-fastapi_users = FastAPIUsers[User, uuid.UUID](get_user_manager, [auth_backend])
+fastapi_users = FastAPIUsers[User, uuid.UUID](get_user_manager, [auth_backend, permanent_jwt_auth_backend])
 
 current_active_user = fastapi_users.current_user(active=True)
 

--- a/application/core/authentication.py
+++ b/application/core/authentication.py
@@ -1,4 +1,6 @@
+import re
 import uuid
+from datetime import datetime
 
 import jwt
 from fastapi import Request
@@ -7,6 +9,8 @@ from fastapi_users import FastAPIUsers
 from fastapi_users.authentication import AuthenticationBackend
 from fastapi_users.authentication import BearerTransport
 from fastapi_users.authentication import JWTStrategy
+from fastapi_users.authentication.strategy.base import Strategy
+from fastapi_users.authentication.strategy.base import StrategyDestroyNotSupportedError
 from fastapi_users.exceptions import InvalidID
 from fastapi_users.exceptions import UserNotExists
 from fastapi_users.jwt import decode_jwt
@@ -14,12 +18,19 @@ from fastapi_users.jwt import generate_jwt
 from httpx_oauth.clients.github import GitHubOAuth2
 from httpx_oauth.clients.google import GoogleOAuth2
 
+from constants.access_tokens import AccessTokenStatuses
 from constants.roles import Roles
 from core.configuration import settings
+from crud.access_tokens import AccessTokenDatabase
+from db.session import session_maker
 from exceptions.common import CommonException
+from exceptions.db import RecordNotFoundException
 from managers.users import UserManager
 from managers.users import get_user_manager
 from models.user import User
+
+
+JWT_PATTERN = re.compile(r'^(?:[\w-]*\.){2}[\w-]*$')
 
 
 class CustomPayloadJWTStrategy(JWTStrategy):
@@ -59,6 +70,34 @@ class CustomPayloadJWTStrategy(JWTStrategy):
         return decode_jwt(token, self.decode_key, self.token_audience, algorithms=[self.algorithm])
 
 
+class PermanentTokenStrategy(Strategy):
+    """
+    Class to extend encoded in JWT token payload.
+    """
+    async def write_token(self, user: User) -> str:
+        raise CommonException('Access token can not be created through common login flow.')
+
+    async def read_token(self, token: str | None, user_manager: UserManager | None = None) -> User | None:
+        if token is None:
+            return
+
+        async with session_maker() as session:
+            access_token_db = AccessTokenDatabase(session)
+            try:
+                token_record = await access_token_db.get(id=token)
+            except RecordNotFoundException:
+                raise CommonException(f'Unknown access token {token}.', status_code=status.HTTP_401_UNAUTHORIZED)
+        if token_record.status != AccessTokenStatuses.active:
+            raise CommonException(f'Token is not usable.', status_code=status.HTTP_403_FORBIDDEN)
+        if token_record.expiration_date is not None and token_record.expiration_date <= datetime.now():
+            raise CommonException(f'Token is expired.', status_code=status.HTTP_403_FORBIDDEN)
+
+        return token_record.user
+
+    async def destroy_token(self, token: str, user: User) -> None:
+        raise StrategyDestroyNotSupportedError('Access token can not be deleted through common logout flow.')
+
+
 github_client = GitHubOAuth2(settings.GITHUB_CLIENT_ID, settings.GITHUB_CLIENT_SECRET, scopes=['user:email'])
 google_client = GoogleOAuth2(settings.GOOGLE_CLIENT_ID, settings.GOOGLE_CLIENT_SECRET)
 bearer_transport = BearerTransport(tokenUrl='api/v1/auth/jwt/login')
@@ -71,17 +110,14 @@ def get_jwt_strategy() -> CustomPayloadJWTStrategy:
 auth_backend = AuthenticationBackend(name='jwt', transport=bearer_transport, get_strategy=get_jwt_strategy,)
 
 
-permanent_jwt_bearer_transport = BearerTransport(tokenUrl='api/v1/auth/permanent-jwt/login')
-
-
-def get_permanent_jwt_strategy() -> CustomPayloadJWTStrategy:
-    return CustomPayloadJWTStrategy(secret=settings.SECRET, lifetime_seconds=None)
+def get_access_token_strategy() -> PermanentTokenStrategy:
+    return PermanentTokenStrategy()
 
 
 permanent_jwt_auth_backend = AuthenticationBackend(
     name='permanent-jwt',
-    transport=permanent_jwt_bearer_transport,
-    get_strategy=get_permanent_jwt_strategy
+    transport=bearer_transport,
+    get_strategy=get_access_token_strategy
 )
 
 fastapi_users = FastAPIUsers[User, uuid.UUID](get_user_manager, [auth_backend, permanent_jwt_auth_backend])
@@ -90,23 +126,37 @@ current_active_user = fastapi_users.current_user(active=True)
 
 
 class BasePermission:
-    def authorize(self, request: Request) -> bool:
+    async def authorize(self, request: Request) -> bool:
         raise NotImplementedError()
 
 
 class BaseRolePermission(BasePermission):
     @classmethod
-    def authorize(cls, request: Request) -> bool:
+    async def authorize(cls, request: Request) -> bool:
         authorization_header = request.headers.get('authorization')
         if not authorization_header:
             raise CommonException(
                 '"Authorization" header is absent in request.',
                 status_code=status.HTTP_401_UNAUTHORIZED
             )
-        jwt_strategy = get_jwt_strategy()
         token = authorization_header[7:]  # Cutting off "Bearer "
+        if JWT_PATTERN.match(token):
+            return cls._authorize_jwt(token)
+        else:
+            return await cls._authorize_access_token(token)
+
+    @classmethod
+    async def _authorize_access_token(cls, token: str) -> bool:
+        strategy = get_access_token_strategy()
+        user = await strategy.read_token(token)
+
+        return user.role == cls.role
+
+    @classmethod
+    def _authorize_jwt(cls, token: str) -> bool:
+        strategy = get_jwt_strategy()
         try:
-            token_data = jwt_strategy.extract_token_data(token)
+            token_data = strategy.extract_token_data(token)
         except jwt.ExpiredSignatureError:
             raise CommonException('Expired JWT token.', status_code=status.HTTP_401_UNAUTHORIZED)
         user_role = token_data.get('user_role')
@@ -134,9 +184,9 @@ class AuthorizedUser:
         if AdminRolePermission not in self.permissions:
             self.permissions = (AdminRolePermission, *self.permissions)
 
-    def __call__(self, request: Request) -> None:
+    async def __call__(self, request: Request) -> None:
         for permission in self.permissions:
-            if permission.authorize(request=request):
+            if await permission.authorize(request=request):
                 break
         else:
             raise CommonException(

--- a/application/core/authentication.py
+++ b/application/core/authentication.py
@@ -73,9 +73,9 @@ class CustomPayloadJWTStrategy(JWTStrategy):
         return decode_jwt(token, self.decode_key, self.token_audience, algorithms=[self.algorithm])
 
 
-class PermanentTokenStrategy(Strategy):
+class AccessTokenStrategy(Strategy):
     """
-    Class to extend encoded in JWT token payload.
+    Strategy to authenticate user by user's access token.
     """
     async def write_token(self, user: User) -> str:
         raise CommonException('Access token can not be created through common login flow.')
@@ -136,20 +136,20 @@ def get_jwt_strategy() -> CustomPayloadJWTStrategy:
     return CustomPayloadJWTStrategy(secret=settings.SECRET, lifetime_seconds=settings.USER_SESSION_TTL)
 
 
-auth_backend = AuthenticationBackend(name='jwt', transport=bearer_transport, get_strategy=get_jwt_strategy,)
+jwt_backend = AuthenticationBackend(name='jwt', transport=bearer_transport, get_strategy=get_jwt_strategy,)
 
 
-def get_access_token_strategy() -> PermanentTokenStrategy:
-    return PermanentTokenStrategy()
+def get_access_token_strategy() -> AccessTokenStrategy:
+    return AccessTokenStrategy()
 
 
-permanent_jwt_auth_backend = AuthenticationBackend(
-    name='permanent-jwt',
+access_token_backend = AuthenticationBackend(
+    name='access-token',
     transport=bearer_transport,
     get_strategy=get_access_token_strategy
 )
 
-fastapi_users = FastAPIUsers[User, uuid.UUID](get_user_manager, [auth_backend, permanent_jwt_auth_backend])
+fastapi_users = FastAPIUsers[User, uuid.UUID](get_user_manager, [jwt_backend, access_token_backend])
 
 current_active_user = fastapi_users.current_user(active=True)
 

--- a/application/crud/access_tokens.py
+++ b/application/crud/access_tokens.py
@@ -1,0 +1,22 @@
+"""
+Classes responsible for interaction with user access token database entities.
+"""
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.session import get_session
+from models.access_token import AccessToken
+
+from .base import BaseDatabase
+
+
+class AccessTokenDatabase(BaseDatabase):
+    """
+    CRUD operation for models.AccessToken instances.
+    """
+    session: AsyncSession
+    table: AccessToken = AccessToken
+
+
+async def get_access_token_db(session=Depends(get_session)):
+    yield AccessTokenDatabase(session)

--- a/application/db/fields.py
+++ b/application/db/fields.py
@@ -1,5 +1,11 @@
 from sqlalchemy import JSON
+from sqlalchemy import Enum
+from enum import Enum as PyEnum
 from sqlalchemy.ext.mutable import MutableDict
 
 
 MutableJSON = MutableDict.as_mutable(JSON)
+
+
+def enum_column(enum: PyEnum) -> Enum:
+    return Enum(enum, values_callable=lambda enum: [item.value for item in enum])

--- a/application/managers/access_tokens.py
+++ b/application/managers/access_tokens.py
@@ -1,0 +1,166 @@
+"""
+User access tokens business logic.
+"""
+from datetime import datetime
+
+from fastapi import Depends
+from fastapi import status
+
+from constants.access_tokens import AccessTokenStatuses
+from constants.events import EventCategory
+from crud.access_tokens import AccessTokenDatabase
+from crud.access_tokens import get_access_token_db
+from exceptions.common import CommonException
+from managers.events import EventManager
+from managers.events import get_event_manager
+from models.access_token import AccessToken
+from models.organization import Organization
+from models.user import User
+from schemas.events import EventSchema
+
+
+class AccessTokenManager:
+    """
+    User access tokens manager.
+    """
+    db: AccessTokenDatabase
+    event_manager: EventManager
+
+    def __init__(self, db: AccessTokenDatabase, event_manager: EventManager) -> None:
+        self.db = db
+        self.event_manager = event_manager
+
+    async def create(
+        self, creator: User, user: User, comment: str | None = None, expiration_date: datetime | None = None
+    ) -> AccessToken:
+        """
+        Creates new user access token.
+        """
+        if comment is None:
+            comment = ''
+        if user.organization.id != creator.organization.id:
+            raise CommonException(
+                'Token creator and token owner belongs to different organizations.',
+                status_code=status.HTTP_412_PRECONDITION_FAILED
+            )
+        token_data = {
+            'status': AccessTokenStatuses.active,
+            'comment': comment,
+            'expiration_date': expiration_date,
+            'user_id': str(user.id),
+            'creator_id': str(creator.id),
+            'organization_id': creator.organization.id
+        }
+        record = await self.db.create(token_data)
+        if expiration_date is None:
+            message = 'Permanent user access token created.'
+        else:
+            message = 'Temporary user access token created.'
+        await self.event_manager.create(EventSchema(
+            title='User access token created.',
+            message=message,
+            organization_id=creator.organization.id,
+            category=EventCategory.access_token,
+            data={
+                'token': str(record.id),
+                'user': str(user.id),
+                'creator': str(creator.id),
+                'expiration_date': expiration_date
+            }
+        ))
+
+        return record
+
+    async def get_access_token(self, organization: Organization, token: str) -> AccessToken:
+        """
+        Returns organization's user access token.
+        """
+        return await self.db.get(organization_id=organization.id, id=token)
+
+    async def list_organization_access_tokens(self, organization: Organization) -> list[AccessToken]:
+        """
+        List organization's user access tokens.
+        """
+        return await self.db.list(organization_id=organization.id)
+
+    async def set_status(self, token: AccessToken, status: AccessTokenStatuses) -> None:
+        """
+        Changes status of user access token.
+        """
+        if status not in AccessTokenStatuses:
+            raise ValueError(f'Unknown user access token status "{status}".')
+        if token.status != status:
+            old_status = token.status
+            token.status = status
+            await self.db.save(token)
+            await self.event_manager.create(EventSchema(
+                title='User access token status changed.',
+                message=f'User access token status changed from {old_status} to {status}.',
+                organization_id=token.organization.id,
+                category=EventCategory.access_token,
+                data={
+                    'token': str(token.id),
+                    'old_status': old_status,
+                    'new_status': status
+                }
+            ))
+
+    async def set_expiration_date(self, token: AccessToken, expiration_date: datetime | None) -> None:
+        """
+        Sets new or removes old access token expiration date.
+        """
+        if token.expiration_date != expiration_date:
+            old_expiration_date = token.expiration_date
+            token.expiration_date = expiration_date
+            await self.db.save(token)
+            await self.event_manager.create(EventSchema(
+                title='User access token expiration date changed.',
+                message=f'User access token expiration date changed from {old_expiration_date} to {expiration_date}.',
+                organization_id=token.organization.id,
+                category=EventCategory.access_token,
+                data={
+                    'token': str(token.id),
+                    'old_expiration_date': old_expiration_date.timestamp() if old_expiration_date is not None else None,
+                    'new_expiration_date': expiration_date.timestamp() if expiration_date is not None else None
+                }
+            ))
+
+    async def set_comment(self, token: AccessToken, comment: str) -> None:
+        """
+        Sets new access token description.
+        """
+        if token.comment != comment:
+            old_comment = token.comment
+            token.comment = comment
+            await self.db.save(token)
+            await self.event_manager.create(EventSchema(
+                title='User access token comment changed.',
+                message=f'User access token comment changed.',
+                organization_id=token.organization.id,
+                category=EventCategory.access_token,
+                data={
+                    'token': str(token.id),
+                    'old_comment': old_comment,
+                    'new_comment': comment
+                }
+            ))
+
+    async def delete_access_token(self, token: AccessToken, deleter: User) -> None:
+        """
+        Deletes user access token.
+        """
+        await self.event_manager.create(EventSchema(
+            title='User access token deleted.',
+            message=f'User access token deleted.',
+            organization_id=token.organization.id,
+            category=EventCategory.access_token,
+            data={
+                'token': str(token.id),
+                'deleted_by': str(deleter.id)
+            }
+        ))
+        await self.db.delete(id=token.id)
+
+
+async def get_access_token_manager(db=Depends(get_access_token_db), event_namager=Depends(get_event_manager)):
+    yield AccessTokenManager(db, event_namager)

--- a/application/managers/access_tokens.py
+++ b/application/managers/access_tokens.py
@@ -65,7 +65,7 @@ class AccessTokenManager:
                 'token': str(record.id),
                 'user': str(user.id),
                 'creator': str(creator.id),
-                'expiration_date': expiration_date
+                'expiration_date': expiration_date.timestamp() if expiration_date is not None else None
             }
         ))
 

--- a/application/migrations/env.py
+++ b/application/migrations/env.py
@@ -9,14 +9,7 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from db.base_class import Base
-from models.application import *
-from models.event import *
-from models.invitation import *
-from models.organization import *
-from models.rule import *
-from models.service import *
-from models.template import *
-from models.user import *
+import models
 
 
 try:

--- a/application/migrations/versions/2022-12-21_1641_added_user_access_token_model.py
+++ b/application/migrations/versions/2022-12-21_1641_added_user_access_token_model.py
@@ -1,0 +1,46 @@
+"""
+Added user access token model.
+
+Revision ID: 288af7dbc2d6
+Revises: 17ba98259c52
+Create Date: 2022-12-21 16:41:18.668676
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '288af7dbc2d6'
+down_revision = '17ba98259c52'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    statuses = sa.Enum('active', 'disabled', name='access_token_statuses')
+    op.create_table(
+        'access_token',
+        sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.text('now()'), nullable=False),
+        sa.Column('status', statuses, nullable=False),
+        sa.Column('expiration_date', sa.DateTime(), nullable=True),
+        sa.Column('comment', sa.String(), nullable=False),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('creator_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('organization_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['creator_id'], ['user.id'], ),
+        sa.ForeignKeyConstraint(['organization_id'], ['organization.id'], ),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_access_token_id'), 'access_token', ['id'], unique=False)
+    op.create_index(op.f('ix_event_id'), 'event', ['id'], unique=False)
+    op.execute("ALTER TYPE event_categories ADD VALUE IF NOT EXISTS 'access_token'")
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_event_id'), table_name='event')
+    op.drop_index(op.f('ix_access_token_id'), table_name='access_token')
+    op.drop_table('access_token')
+    statuses = sa.Enum('active', 'disabled', name='access_token_statuses')
+    statuses.drop(op.get_bind())

--- a/application/migrations/versions/2022-12-23_1328_removed_creator_from_accesstoken_model.py
+++ b/application/migrations/versions/2022-12-23_1328_removed_creator_from_accesstoken_model.py
@@ -1,0 +1,28 @@
+"""
+Removed creator from AccessToken model.
+
+Revision ID: cb7e2af4e17c
+Revises: 288af7dbc2d6
+Create Date: 2022-12-23 13:28:11.549646
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'cb7e2af4e17c'
+down_revision = '288af7dbc2d6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint('access_token_creator_id_fkey', 'access_token', type_='foreignkey')
+    op.drop_column('access_token', 'creator_id')
+    op.create_index(op.f('ix_event_id'), 'event', ['id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_event_id'), table_name='event')
+    op.add_column('access_token', sa.Column('creator_id', postgresql.UUID(), autoincrement=False, nullable=True))
+    op.create_foreign_key('access_token_creator_id_fkey', 'access_token', 'user', ['creator_id'], ['id'])

--- a/application/migrations/versions/2022-12-23_1328_removed_creator_from_accesstoken_model.py
+++ b/application/migrations/versions/2022-12-23_1328_removed_creator_from_accesstoken_model.py
@@ -19,10 +19,8 @@ depends_on = None
 def upgrade() -> None:
     op.drop_constraint('access_token_creator_id_fkey', 'access_token', type_='foreignkey')
     op.drop_column('access_token', 'creator_id')
-    op.create_index(op.f('ix_event_id'), 'event', ['id'], unique=False)
 
 
 def downgrade() -> None:
-    op.drop_index(op.f('ix_event_id'), table_name='event')
     op.add_column('access_token', sa.Column('creator_id', postgresql.UUID(), autoincrement=False, nullable=True))
     op.create_foreign_key('access_token_creator_id_fkey', 'access_token', 'user', ['creator_id'], ['id'])

--- a/application/models/__init__.py
+++ b/application/models/__init__.py
@@ -1,3 +1,4 @@
+from . import access_token
 from . import application
 from . import event
 from . import invitation

--- a/application/models/access_token.py
+++ b/application/models/access_token.py
@@ -27,7 +27,6 @@ class AccessToken(Base):
     status - status of access token.
     comment - description for this access token.
     user_id - identifier of User to which belongs the access token.
-    creator_id - identifier of User record that created this access token.
     organization_id - identifier of the organization to which access token
                       belongs.
     """
@@ -37,8 +36,6 @@ class AccessToken(Base):
     expiration_date = Column(DateTime, nullable=True)
     comment = Column(String, nullable=False, default='')
     user_id = Column(UUID(as_uuid=True), ForeignKey('user.id'), nullable=False)
-    user = relationship('User', back_populates='access_tokens', lazy='selectin', foreign_keys=user_id)
-    creator_id = Column(UUID(as_uuid=True), ForeignKey('user.id'), nullable=False)
-    creator = relationship('User', back_populates='created_access_tokens', lazy='selectin', foreign_keys=creator_id)
+    user = relationship('User', back_populates='access_tokens', lazy='selectin')
     organization_id = Column(Integer, ForeignKey('organization.id'), nullable=False)
     organization = relationship('Organization', back_populates='access_tokens', lazy='selectin')

--- a/application/models/access_token.py
+++ b/application/models/access_token.py
@@ -1,0 +1,44 @@
+"""
+User invitation model
+"""
+from uuid import uuid4
+
+from sqlalchemy import CheckConstraint
+from sqlalchemy import Column
+from sqlalchemy import DateTime
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from constants.access_tokens import AccessTokenStatuses
+from db.base_class import Base
+from db.fields import enum_column
+
+
+class AccessToken(Base):
+    """
+    User access token.
+
+    id - unique identifier.
+    created_at - date when access token was created.
+    status - status of access token.
+    comment - description for this access token.
+    user_id - identifier of User to which belongs the access token.
+    creator_id - identifier of User record that created this access token.
+    organization_id - identifier of the organization to which access token
+                      belongs.
+    """
+    id = Column(UUID(as_uuid=True), primary_key=True, index=True, default=uuid4)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+    status = Column(enum_column(AccessTokenStatuses), nullable=False)
+    expiration_date = Column(DateTime, nullable=True)
+    comment = Column(String, nullable=False, default='')
+    user_id = Column(UUID(as_uuid=True), ForeignKey('user.id'), nullable=False)
+    user = relationship('User', back_populates='access_tokens', lazy='selectin', foreign_keys=user_id)
+    creator_id = Column(UUID(as_uuid=True), ForeignKey('user.id'), nullable=False)
+    creator = relationship('User', back_populates='created_access_tokens', lazy='selectin', foreign_keys=creator_id)
+    organization_id = Column(Integer, ForeignKey('organization.id'), nullable=False)
+    organization = relationship('Organization', back_populates='access_tokens', lazy='selectin')

--- a/application/models/event.py
+++ b/application/models/event.py
@@ -1,7 +1,6 @@
 from sqlalchemy import JSON
 from sqlalchemy import Column
 from sqlalchemy import DateTime
-from sqlalchemy import Enum
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import String
@@ -11,10 +10,7 @@ from sqlalchemy.sql import func
 from constants.events import EventCategory
 from constants.events import EventSeverityLevel
 from db.base_class import Base
-
-
-EventCategoryType = Enum(EventCategory, values_callable=lambda enum: [item.value for item in enum])
-EventSeverityLevelType = Enum(EventSeverityLevel, values_callable=lambda enum: [item.value for item in enum])
+from db.fields import enum_column
 
 
 class Event(Base):
@@ -25,8 +21,8 @@ class Event(Base):
     created_at = Column(DateTime, server_default=func.now(), nullable=False)
     title = Column(String, nullable=False)
     message = Column(String, nullable=False)
-    category = Column(EventCategoryType, nullable=False)
-    severity = Column(EventSeverityLevelType, nullable=False)
+    category = Column(enum_column(EventCategory), nullable=False)
+    severity = Column(enum_column(EventSeverityLevel), nullable=False)
     data = Column(JSON, nullable=False, default={})
     organization_id = Column(Integer, ForeignKey('organization.id'), nullable=False)
     organization = relationship('Organization', back_populates='events', lazy='selectin')

--- a/application/models/organization.py
+++ b/application/models/organization.py
@@ -22,3 +22,4 @@ class Organization(Base):
     applications = relationship('Application', back_populates='organization', lazy='selectin')
     invitations = relationship('UserInvitation', back_populates='organization', lazy='selectin')
     events = relationship('Event', back_populates='organization', lazy='selectin')
+    access_tokens = relationship('AccessToken', back_populates='organization', lazy='selectin')

--- a/application/models/user.py
+++ b/application/models/user.py
@@ -31,9 +31,4 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
         'UserInvitation', back_populates='created_user', lazy='selectin', uselist=False,
         foreign_keys='UserInvitation.created_user_id'
     )
-    created_access_tokens = relationship(
-        'AccessToken', back_populates='creator', lazy='selectin', foreign_keys='AccessToken.creator_id'
-    )
-    access_tokens = relationship(
-        'AccessToken', back_populates='user', lazy='selectin', foreign_keys='AccessToken.user_id'
-    )
+    access_tokens = relationship('AccessToken', back_populates='user', lazy='selectin',)

--- a/application/models/user.py
+++ b/application/models/user.py
@@ -31,3 +31,9 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
         'UserInvitation', back_populates='created_user', lazy='selectin', uselist=False,
         foreign_keys='UserInvitation.created_user_id'
     )
+    created_access_tokens = relationship(
+        'AccessToken', back_populates='creator', lazy='selectin', foreign_keys='AccessToken.creator_id'
+    )
+    access_tokens = relationship(
+        'AccessToken', back_populates='user', lazy='selectin', foreign_keys='AccessToken.user_id'
+    )

--- a/application/schemas/access_tokens.py
+++ b/application/schemas/access_tokens.py
@@ -22,7 +22,6 @@ class AccessTokenBaseSchema(BaseModel):
 
 class AccessTokenSchema(BaseModel):
     user_id: UUID = Field(description='ID of user which token represents.')
-    creator_id: UUID = Field(description='ID of user who have created this token.')
     organization_id: int = Field(description='ID of organization to which token belongs.')
 
     class Config:

--- a/application/schemas/access_tokens.py
+++ b/application/schemas/access_tokens.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel
+from pydantic import Extra
+from pydantic import Field
+
+from constants.access_tokens import AccessTokenStatuses
+
+
+class AccessTokenBaseSchema(BaseModel):
+    id: UUID = Field(description='Access token itself.')
+    created_at: datetime = Field(description='Token creation date and time.')
+    status: AccessTokenStatuses = Field(description='Token status.')
+    comment: str = Field(description='Token description.')
+    expiration_date: datetime | None = Field(description='Date when token expires.')
+
+    class Config:
+        extra = Extra.forbid
+        orm_mode = True
+
+
+class AccessTokenSchema(BaseModel):
+    user_id: UUID = Field(description='ID of user which token represents.')
+    creator_id: UUID = Field(description='ID of user who have created this token.')
+    organization_id: int = Field(description='ID of organization to which token belongs.')
+
+    class Config:
+        extra = Extra.forbid
+        orm_mode = True

--- a/frontend/src/app/main/applications/ApplicationsTable.js
+++ b/frontend/src/app/main/applications/ApplicationsTable.js
@@ -32,8 +32,6 @@ import { getTemplatesList } from 'app/store/templatesSlice';
 import { useGetMe } from '../../hooks/useGetMe';
 import { getPresent } from '../../uitls';
 
-import { getPresent } from '../../uitls';
-
 import ApplicationsModal from './ApplicationsModal';
 import ApplicationTtl from './ApplicationTtl';
 import DeleteApplicationModal from './DeleteApplicationModal';


### PR DESCRIPTION
Added possibility to interact with API using access token. User can be authenticated and authorized with access token.
Added next endpoints:
- To create access token
- To list access token
- To set status
- To set comment
- To set expiration date
- To delete access token

Example of usage: `curl -X 'GET' 'http://localhost:8000/api/v1/application/list' -H 'accept: application/json' -H 'Authorization: Bearer 603d29d1-5453-4838-a1f9-f426ea3e4d64'`.